### PR TITLE
Update to improve compatibility with recorded macros

### DIFF
--- a/sheets/performSheetsAction.gs
+++ b/sheets/performSheetsAction.gs
@@ -47,6 +47,7 @@ function actWorkSheets_(func) {
     sheet = sheets[i];
     sheetName = sheet.getName();
     if (getSheetMatchs_(sheetName)) {
+      sheet.activate();
       func(sheet, sheetName);
     }
   }


### PR DESCRIPTION
Macros usually use `var spreadsheet = SpreadsheetApp.getActive();` at the start and by activating the sheet easier to drop in recorded macro functions to `performSets{}`